### PR TITLE
fix: `commands.NotOwner` error will do nothing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .venv
 .env
+bolb.db

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 hi yes this is the shitcode of bolb bot.
 have fun.
 
-written by [koala#9712](https://github.com/koala9712), [Sham#0002](https://github.com/realShamlol) and [ooliver#6969](https://github.com/ooliver1) ofc
+written by [koala#9712](https://github.com/koala9712), [Sham#2412](https://github.com/toolifelesstocode) and [ooliver#6969](https://github.com/ooliver1) ofc
 
 ## Deploying
 

--- a/bolb_bot/cogs/events.py
+++ b/bolb_bot/cogs/events.py
@@ -11,6 +11,7 @@ from nextcord.ext.commands import (
     Context,
     MissingRequiredArgument,
     TooManyArguments,
+    NotOwner
 )
 from nextcord.utils import utcnow
 from nextcord import Embed, NotFound, Forbidden
@@ -58,6 +59,8 @@ class Events(Cog):
             return
         elif isinstance(error, MissingRequiredArgument):
             await ctx.send("You're missing a required argument.")
+        elif isinstance(error, NotOwner):
+            return
         else:
             embed = Embed(
                 title="Unexpected Error.",


### PR DESCRIPTION
Few Changes:
- Changed my Github username and Discord discriminator
- Made bolb.db git-ignored
- If a command error is `commands.NotOwner` it will return and do nothing, seeing as people keep using the `jiskahu`/`jsk` command when they are not the bot owner and it keeps DM-ing the bot owners this error.